### PR TITLE
Allow user to override install location

### DIFF
--- a/AstroGrep.nuspec
+++ b/AstroGrep.nuspec
@@ -6,6 +6,9 @@
     <version>4.4.6</version>
     <packageSourceUrl>https://github.com/PaulWalkerUK/Chocolatey-AstroGrep</packageSourceUrl>
     <owners>IanC, P72endragon</owners>
+    <dependencies>
+        <dependency id="chocolatey-core.extension" version="1.1.0" />
+    </dependencies>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>AstroGrep</title>
     <authors>Theodore Ward,Curtis Beard</authors>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,7 +1,25 @@
-﻿$installParams = @{
+﻿<#
+.EXAMPLE
+choco install astrogrep
+Install AstroGrep to the default location:
+C:\Program Files (x86)\AstroGrep
+
+.EXAMPLE
+choco install astrogrep --params "/installPath:'e:\apps folder\astrogrep'"
+Install AstroGrep to the specified location
+#>
+
+$pp = Get-PackageParameters
+$installPath = ''
+
+If ($pp['installPath']) { 
+    $installPath = "/D=$($pp['installPath'])" 
+}
+
+$installParams = @{
     PackageName = 'astrogrep'
     FileType = 'exe'
-    SilentArgs = '/S'
+    SilentArgs = "/S $installPath"
     Url = 'https://downloads.sourceforge.net/project/astrogrep/AstroGrep%20%28Win32%29/AstroGrep%20v4.4.6/AstroGrep_Setup_v4.4.6.exe'
     Checksum = 'CD544F508837122389669AE031DD40F71F4147FFC6A4F5948A22DE8BEAAE74C5B3310EBBFCAF4818AF9E279425AEA2D62D0E927933F1B61465D35AB97BCB9DBF'
     ChecksumType = 'sha512'


### PR DESCRIPTION
By default, AstroGrep will install into
`C:\Program Files (x86)\AstroGrep`.

Now, the user can override this by specifying the install location as a
parameter on the end of the `choco install astrogrep` command