### PR TITLE
V4.4.7

### DIFF
--- a/AstroGrep.nuspec
+++ b/AstroGrep.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>astrogrep</id>
-    <version>4.4.6</version>
+    <version>4.4.7</version>
     <packageSourceUrl>https://github.com/PaulWalkerUK/Chocolatey-AstroGrep</packageSourceUrl>
     <owners>IanC, P72endragon</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
@@ -11,7 +11,7 @@
     <authors>Theodore Ward,Curtis Beard</authors>
     <projectUrl>http://astrogrep.sourceforge.net/</projectUrl>
     <iconUrl>https://cdn.rawgit.com/PaulWalkerUK/Chocolatey-AstroGrep/c603335dae051713e6a7def1ee40f3a09f41c90a/AstroGrep_256x256.png</iconUrl>
-    <licenseUrl>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</licenseUrl>
+    <licenseUrl>https://www.gnu.org/copyleft/gpl.html</licenseUrl>
     <projectSourceUrl>https://sourceforge.net/projects/astrogrep</projectSourceUrl>
     <docsUrl>http://astrogrep.sourceforge.net/features/</docsUrl>
     <mailingListUrl>https://sourceforge.net/p/astrogrep/discussion/184597/</mailingListUrl>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
     PackageName = 'astrogrep'
     FileType = 'exe'
     SilentArgs = '/S'
-    Url = 'https://downloads.sourceforge.net/project/astrogrep/AstroGrep%20%28Win32%29/AstroGrep%20v4.4.6/AstroGrep_Setup_v4.4.6.exe'
-    Checksum = 'CD544F508837122389669AE031DD40F71F4147FFC6A4F5948A22DE8BEAAE74C5B3310EBBFCAF4818AF9E279425AEA2D62D0E927933F1B61465D35AB97BCB9DBF'
+    Url = 'https://downloads.sourceforge.net/project/astrogrep/AstroGrep%20%28Win32%29/AstroGrep%20v4.4.7/AstroGrep_Setup_v4.4.7.exe'
+    Checksum = '8E2FA5F33E16879D8F5ACB4AB783AA4B4B37266CD1346ABEF5D54F2DFEB2177AF872575780E2E7CD02E462349B1C35642C0F7BA3F860034775A064E9A07B08AF'
     ChecksumType = 'sha512'
 }
 

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,10 +1,16 @@
-﻿$installParams = @{
-    PackageName = 'astrogrep'
-    FileType = 'exe'
-    SilentArgs = '/S'
-    Url = 'https://downloads.sourceforge.net/project/astrogrep/AstroGrep%20%28Win32%29/AstroGrep%20v4.4.7/AstroGrep_Setup_v4.4.7.exe'
-    Checksum = '8E2FA5F33E16879D8F5ACB4AB783AA4B4B37266CD1346ABEF5D54F2DFEB2177AF872575780E2E7CD02E462349B1C35642C0F7BA3F860034775A064E9A07B08AF'
-    ChecksumType = 'sha512'
+﻿$ErrorActionPreference = 'Stop'
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url        = 'https://downloads.sourceforge.net/project/astrogrep/AstroGrep%20%28Win32%29/AstroGrep%20v4.4.7/AstroGrep_Setup_v4.4.7.exe'
+
+$packageArgs = @{
+    packageName   = $env:ChocolateyPackageName
+    unzipLocation = $toolsDir
+    fileType      = 'exe'
+    url           = $url
+    softwareName  = 'astrogrep*'
+    checksum      = '8E2FA5F33E16879D8F5ACB4AB783AA4B4B37266CD1346ABEF5D54F2DFEB2177AF872575780E2E7CD02E462349B1C35642C0F7BA3F860034775A064E9A07B08AF'
+    checksumType  = 'sha512'
+    silentArgs    = '/S'
 }
 
-Install-ChocolateyPackage @installParams
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Chocolatey installer for: AstroGrep v4.4.7
Published to: https://chocolatey.org/packages/AstroGrep/4.4.7
(Note: this was uploaded to Chocolatey 17/04/2019)